### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 Tooner is a lightweight MCP wrapper that keeps your server setup unchanged, but makes model-facing responses cleaner and shorter. It rewrites JSON-heavy outputs into [TOON format](https://toonformat.dev/) so models spend fewer tokens on syntax noise (~40% fewer tokens).
 
+<a href="https://glama.ai/mcp/servers/chaindead/tooner">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/chaindead/tooner/badge" alt="TOONer MCP server" />
+</a>
+
 - [What it does](#what-it-does)
 - [Installation](#installation)
   - [Homebrew](#homebrew)


### PR DESCRIPTION
This PR adds a badge for the [TOONer](https://glama.ai/mcp/servers/chaindead/tooner) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/chaindead/tooner">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/chaindead/tooner/badge" alt="TOONer MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.